### PR TITLE
change maintainer to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM busybox
 
-MAINTAINER Tom Denham <tom@tigera.io>
+LABEL maintainer "Tom Denham <tom@tigera.io>"
 
 ADD dist/calico /opt/cni/bin/calico
 ADD dist/flannel /opt/cni/bin/flannel


### PR DESCRIPTION
## Description
<!-- i changed the maintainer to label, since the former is deprecated.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
-->

